### PR TITLE
Add icon library package to the frontend

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^17.0.2",
         "react-bootstrap": "^2.0.0-rc.0",
         "react-dom": "^17.0.2",
+        "react-icons": "^4.3.1",
         "react-if": "^4.1.1",
         "react-scripts": "4.0.3",
         "web-vitals": "^1.1.2",
@@ -16885,6 +16886,14 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-if": {
       "version": "4.1.1",
@@ -35073,6 +35082,12 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "requires": {}
     },
     "react-if": {
       "version": "4.1.1",

--- a/application/package.json
+++ b/application/package.json
@@ -9,6 +9,7 @@
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.0-rc.0",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.3.1",
     "react-if": "^4.1.1",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.1.2",

--- a/application/src/components/HomePage.js
+++ b/application/src/components/HomePage.js
@@ -1,10 +1,23 @@
 import './components.css';
+import {IconContext} from 'react-icons';
+import {MdHome, MdSearch, MdAddLocation, MdRefresh, MdMoreHoriz} from 'react-icons/md';
+import {FaHome, FaSearch, FaSearchLocation, FaRedoAlt, FaMapMarkerAlt, FaEllipsisH} from 'react-icons/fa';
 
 // Homepage component for the application
 function HomePage() {
   return (
     <div className="home-page" data-testid="home-page">
       HomePage
+      <br/>
+      <br/>
+      <div style={{textAlign:'left'}}>
+        <b>Sample Icons</b><br/>
+        <IconContext.Provider value={{color:'#EC4038'}} style={{textAlign:'left'}}>
+        <div>Material Design: <MdHome/><MdSearch/><MdAddLocation/><MdRefresh/><MdMoreHoriz/></div>
+        <div>Fontawesome: <span style={{marginRight:'10px'}}><FaHome/><FaSearch/><FaSearchLocation/><FaMapMarkerAlt/><FaRedoAlt/><FaEllipsisH/></span></div>
+        </IconContext.Provider>
+        <div>Available icons: <a href='https://react-icons.github.io/react-icons/'>https://react-icons.github.io/react-icons/</a></div>
+      </div>
     </div>
   )
 }

--- a/application/src/components/HomePage.js
+++ b/application/src/components/HomePage.js
@@ -14,9 +14,8 @@ function HomePage() {
         <b>Sample Icons</b><br/>
         <IconContext.Provider value={{color:'#EC4038'}} style={{textAlign:'left'}}>
         <div>Material Design: <MdHome/><MdSearch/><MdAddLocation/><MdRefresh/><MdMoreHoriz/></div>
-        <div>Fontawesome: <span style={{marginRight:'10px'}}><FaHome/><FaSearch/><FaSearchLocation/><FaMapMarkerAlt/><FaRedoAlt/><FaEllipsisH/></span></div>
+        <div>Fontawesome: <FaHome/><FaSearch/><FaSearchLocation/><FaMapMarkerAlt/><FaRedoAlt/><FaEllipsisH/></div>
         </IconContext.Provider>
-        <div>Available icons: <a href='https://react-icons.github.io/react-icons/'>https://react-icons.github.io/react-icons/</a></div>
       </div>
     </div>
   )


### PR DESCRIPTION
After a little research, I found the great package `react-icons` which is basically a bundled version of many other package libraries (including Font Awesome, Material Design icons, and a bunch of others).

The full list of the icon packages and their icons can be found at https://react-icons.github.io/react-icons.

I added a sample of the icons I used in my Figma wireframes to the welcome page: 
(I used the Material Design icons for the wireframes)
![image](https://user-images.githubusercontent.com/43451024/139602565-0b0c8f37-d3b6-4bc2-b5e6-b6daef1fbf58.png)

