### PR TITLE
Major CSS overhaul of Post component.

### DIFF
--- a/application/src/App.css
+++ b/application/src/App.css
@@ -7,7 +7,6 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
   color: black;
 }
 

--- a/application/src/components/FlexContainers.js
+++ b/application/src/components/FlexContainers.js
@@ -1,0 +1,38 @@
+// React
+import PropTypes from 'prop-types'
+
+// Stylesheet
+import './components.css';
+
+// These FRow and FCol components are just container divs with a specific class attached to them.
+// The "complicated stuff" is just so that it preserves props and classes given, and allow children within them.
+
+function FRow(props) {
+  const {children, className, ...otherProps} = props;
+  return (
+    <div className={'f-row ' + (className??'')} {...otherProps} >
+        {children}
+    </div>
+  );
+}
+
+FRow.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string
+}
+
+function FCol(props) {
+  const {children, className, ...otherProps} = props;
+  return (
+    <div className={'f-col ' + (className??'')} {...otherProps} >
+        {children}
+    </div>
+  );
+}
+
+FCol.propTypes = {
+  children: PropTypes.node, // <- this is the HTML elements inside this component
+  className: PropTypes.string
+}
+
+export {FRow, FCol};

--- a/application/src/components/Post.js
+++ b/application/src/components/Post.js
@@ -1,5 +1,5 @@
 // React
-import { Container, Row, Col } from 'react-bootstrap';
+import { Container } from 'react-bootstrap';
 import PropTypes from 'prop-types'
 
 // Stylesheet
@@ -7,53 +7,46 @@ import './post.css';
 
 // Resources
 import StaticMap from './maps/StaticMap';
+import { FRow, FCol } from './FlexContainers';
 
 function Post({postData}) {
 
   // Create Tags for rendering
   const tags = postData.tags.map(tag => {
-    return <span id="tags" key={tag}>{tag}</span>;
+    return <span className="tag" key={tag}>{tag}</span>;
   });
 
   return (
-    <Container id="outer-container">
-      <Row>
-        <Col xs={{ order: 0 }} id="profile">
-          <img id="avatar" src={postData.avatar} />
-          <p id="user-name">{postData.user}</p>
-        </Col>
+    <Container className="outer-container">
+      <FRow>
+        <FCol>
+          <img className="avatar" src={postData.avatar} />
+          <div className="user-name">{postData.user}</div>
+        </FCol>
 
-        <Col id="post">
-          <Row className="justify-content-md-center">
-            <Col xs={{ span: 12, order: 1 }} md={{ span: 6, order: 1 }} id="post-description">
-              <div id="title-section">
-                <p id="post-title">{postData.title}</p> 
-                <p id="post-date">{postData.date}</p>
-              </div>
-              <p id="post-body">{postData.postBody}</p>
-              <div id="tag-container-sm">
+        <FCol>
+          <FRow className="post-content">
+            <FCol  className="post-description">
+              <FRow className="title-section">
+                <div className="post-title">{postData.title}</div> 
+                <div className="grey">{postData.date}</div>
+              </FRow>
+              <div className="post-body">{postData.postBody}</div>
+              <FRow className="tag-container">
                 {tags}
-              </div>
-            </Col>
+              </FRow>
+            </FCol>
 
-            <Col xs={{ span: 12, order: 2 }} md={{ span: 6, order: 2 }} id="post-location" className="col-md-5 mx-auto">
-              <div id="map">
-                <StaticMap width={313} height={188} position={postData.position}/>
-              </div>
-              <p id="map-description">{postData.location}</p>
-            </Col>
-          </Row>
-
-          <Row>
-            <div id="tag-container">
-                {tags}
-            </div>
-            <div className="col-md-5 mx-auto" id="post-image-container">
-              <img src={postData.postImage} />
-            </div>
-          </Row>
-        </Col>
-      </Row>
+            <FCol className="post-location">
+              <StaticMap width={2000} height={200} position={postData.position}/>
+              <div className="grey map-description">{postData.location}</div>
+            </FCol>
+          </FRow>
+          <div>
+            <img src={postData.postImage} />
+          </div>
+        </FCol>
+      </FRow>
     </Container> 
   )
 }

--- a/application/src/components/WelcomePage.js
+++ b/application/src/components/WelcomePage.js
@@ -39,9 +39,9 @@ function WelcomePage(props) {
     <div className="container">
       <img className="logo" src={logo} alt="Logo" />
       <div className="terms-conditions" data-testid="terms-conditions">
-        <p>By entering this website, you are ageering to our {termsAndConditions}.</p>
+        <p className="h5">By entering this website, you are ageering to our {termsAndConditions}.</p>
       </div>
-      <div className="i-agree">
+      <div className="i-agree h5">
         <Form.Check
           data-testid="agree-checkbox"
           id="agree-checkbox"

--- a/application/src/components/components.css
+++ b/application/src/components/components.css
@@ -37,6 +37,24 @@ label {
     cursor: pointer;
 }
 
+.f-row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    gap: 10px;
+}
+
+.f-col {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    gap: 10px;
+}
+
+.grey {
+    color: #A09F9F;
+}
+
 /* IDs */
 
 #terms-conditions-link {

--- a/application/src/components/post.css
+++ b/application/src/components/post.css
@@ -2,229 +2,94 @@
 img {
     width: 100%;
     height: 100%;
-    border-radius: 10px;
+    border-radius: 20px;
     object-fit: cover;
 }
 
-/* ID's */
-#outer-container {
+/* Classes */
+
+div.outer-container { /* The div is added so it takes precedence over bootstrap's CSS */
     padding: 20px;
-    margin-top: 50px;
-    margin-bottom: 50px;
-    width: 1080px;
-    height: 100%;
     background: #ffff;
     border-radius: 20px;
 }
 
-#profile {
-    width: 100px;
-}
-
-#avatar {
+.avatar {
     width: 90px;
     height: 90px;
     border-radius: 50px;
     overflow: hidden;
 }
 
-#user-name {
-    padding-top: 10px;
-    font-size: 18px;
-    line-height: 20px;
+.user-name {
+    /* Allow breaking names to fit in the avatar column */
     overflow-wrap: break-word;
     hyphens: auto;
 }
 
-#post {
-    padding: 0px;
-    width: 940px;
-}
-
-#post-description {
+.post-description {
     display: flex;
     flex-direction: column;
     text-align: left;
-    padding: 10px;
-    max-width: 607px;
-    width: 100%;
+    width: 70%; /* Take 70% of post width, leaving 30% for map */
 }
 
-#title-section {
-    width: 100%;
-    height: 21px;
+.title-section {
+    /* Make the title & date stay at opposite ends */
+    justify-content: space-between;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    gap: 0 10px;
 }
 
-#post-title {
+.post-title {
     font-weight: bold;
-    font-size: 18px;
-    line-height: 5px;
     overflow-wrap: break-word;
     hyphens: auto;
-    text-align: left;
 }
 
-#post-date {
-    position: relative;
-    bottom: 21px;
-    font-weight: 200;
-    font-size: 16px;
-    line-height: 5px;
-    text-align: right;
-    color: #4e4e4e;
-}
-
-#post-body {
-    font-size: 16px;
-    line-height: 19px;
+.post-body {
+    /* Keep extra whitespace inside the description of the post (e.g., newlines) */
     white-space: pre-wrap;
-    --body-height: height;
 }
 
-#tag-container {
-    display: flex;
-    align-items: center;
-    height: 23px;
-    align-self: left;
-    padding-bottom: 20px;
+.tag-container {
+    /* Allow tags to wrap to a new line */
+    flex-wrap: wrap;
 }
 
-#tag-container-sm {
-    display: none;
-}
-
-#tags {
-    padding: 2px 5px;
-    margin-right: 10px;
+.tag {
+    padding: 2px 8px;
     border: 1px solid var(--bs-primary);
-    border-radius: 10px;
-    font-size: 15px;
-    line-height: 19px;
+    border-radius: 20px;
 }
 
-#post-location {
-    padding-left: 0px;
-    padding-right: 5px;
-    width: 313px;
-    height: 217px;
+.post-location {
+    width: 30%; /* Take 30% of post width, leaving 70% for body */
 }
 
-#map-description {
-    font-size: 16px;
-    line-height: 19px;
+.map-description {
     text-align: center;
 }
 
-#post-image-container {
-    width: 940px;
-    height: 573px;
-    padding-right: 15px;
-}
-
-/* For screens that are 1200px or less */
-@media screen and (max-width: 1200px) {
-    #map {
-        height: 100%;
-    }
-
-    #post-location {
-        display: flex;
-        padding-right: 10px;
-        flex-direction: column;
-        height: var(--body-height);
-    }
-
-    #profile {
-        max-width: 120px;
-    }
-
-    #post-description {
-        max-width: 500px;
-    }
-
-    #post-image-container {
-        width: 100%;
-        height: 100%;
-    }
-}
-
-/* For screens that are 992px or less */
-@media only screen and (max-width: 992px) {
-    #post-description {
-        width: 60%;
-    }
-
-    #post-location {
-        width: 40%;
-        height: var(--body-height);
-    }
-
-    #outer-container {
-        height: 100%;
-        background: rgb(14, 211, 113);
-    }
-}
-
 /* For screens that are 768px or less */
-@media only screen and (max-width: 768px) {
-    #outer-container {
-        width: 100%;
-        height: 100%;
-        background: red;
-    }
-
-    #post-date {
-        text-align: left;
-        padding-top: 18px;
-    }
-
-    #post-body {
-        padding-top: 20px;
-    }
-
-    #post-location {
-        height: var(--body-height);
-        padding-bottom: 25px;
-        width: 45%;
-    }
-
-    #post-description {
-        padding-left: 20px;
-        width: 55%;
-    }
-
-    #avatar {
+@media screen and (max-width: 768px) {
+    .avatar {
+        /* Reduce avatar size on small screens */
         width: 80px;
         height: 80px;
-    }
-
-    #profile {
-        max-width: 100px;
     }
 }
 
 /* For screens that are 576px or less */
-@media only screen and (max-width: 576px) {
-    #outer-container {
-        width: 50%;
-        background: rgb(0, 26, 255);
+@media screen and (max-width: 576px) {
+    div.outer-container {
+        /* Reduce padding around the overall post on smaller screens */
+        padding: 10px;
     }
 
-    #post-location {
-        height: var(--body-height);
-        width: 50%;
-    }
-
-    #post-description {
-        padding-left: 10px;
-        width: 50%;
-    }
-
-    #post-image-container {
-        width: 100%;
-    }
-
-    #avatar {
+    .avatar {
+        /* Reduce avatar size on smaller screens (even more) */
         width: 70px;
         height: 70px;
     }
@@ -232,28 +97,9 @@ img {
 
 /* For screens that are 450px or less (For Phone Browsers)*/
 @media screen and (max-width: 480px) {
-    #post-location {
-        width: 90%;
-        height: 200px;
-    }
 
-    #outer-container {
-        width: 40%;
-        background: rgb(234, 0, 255);
-    }
-
-    #post-description {
-        width: 100%;
-    }
-
-    #tag-container-sm {   
-        display: flex;
-        align-items: center;
-        height: 23px;
-        align-self: left;
-    }
-
-    #tag-container {
-        display: none;
-    }
+    /* Switch the map to be below post body on small screens (mobile) */
+    .post-content { flex-direction: column; }
+    .post-description { width: 100%; }
+    .post-location { width: 100%; }
 }

--- a/application/src/custom.scss
+++ b/application/src/custom.scss
@@ -1,6 +1,8 @@
 // Override default variables
+// (To see what variables we can override, look at the _variables.scss file at: node_modules/bootstrap/scss/_variables.scss)
 $primary: #EC4038;
 $min-contrast-ratio: 3.9; // Contrast ratio was reduced so that white text would be used over the primary color
+$line-height-base: 1.25;
 
 // Import Bootstrap and its default variables
 @import '~bootstrap/scss/bootstrap.scss';


### PR DESCRIPTION
**NOTE: THIS PR MERGES INTO SAHIL's PR (#39), NOT DEV**

Reworked the Post component so that the CSS is not conflicted between the old Figma CSS and bootstrap's CSS.

Major Changes:
- Created custom Row/Col elements instead of using bootstrap's ones to have more control over padding between rows/cols. (the custom ones I made are just simple divs with a flex-box style attached to them).
- Removed all unnecessary/redundant CSS.
- Improved flexibility of elements so they resize based on the overall size of the outer-container (which is controlled by bootstrap). This means that no element has a static size (except the avatar image).
- Changed CSS rules from ids to classes since multiple posts will be on a page at the same time (ids are for unique elements).
- Removed the global `font-size:20px` that was set on the App to instead rely on bootstrap's default font-size (which is in turn based on the browser's default font-size). If we want to make something with a different font size we should use `rem` relative sizes or the heading classes `h1` (biggest) through `h6` (normal).