### PR TITLE
Fix Post image preview not showing when creating post

### DIFF
--- a/application/src/components/post/Post.js
+++ b/application/src/components/post/Post.js
@@ -2,7 +2,8 @@
 import { Container, Button, Modal } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { When } from 'react-if';
+import { useState, useEffect } from 'react';
 
 // Stylesheet
 import './post.css';
@@ -18,12 +19,17 @@ function handleAvatarImgError(e) {
 }
 
 function Post({postData}) {
-  const [imgURL, setimgURL] = useState(postData.img_url);
+  const [imgURL, setImgURL] = useState(null);
 
   // Show no image if post picture fails
   const handlePictureImgError = () => {
-    setimgURL(null);
+    setImgURL(null);
   }
+
+  useEffect(() => {
+    // Update imgURL stat based on img_url prop
+    setImgURL(postData.img_url);
+  }, [postData.img_url]);
 
   const [postImageModal, setPostImageModal] = useState(false);
   const [avatarImageModal, setAvatarImageModal] = useState(false);
@@ -66,11 +72,13 @@ function Post({postData}) {
                 <div className="text-muted text-center">{postData.location_string}</div>
               </FCol>
             </FRow>
-            <FRow className="post-image" hidden={!imgURL}>
-              <button className="image-button" onClick={() => setPostImageModal(true)}>
-                <img data-testid="post-image" className="clickable hover-outline" src={imgURL} onError={handlePictureImgError}/>
-              </button>
-            </FRow>
+            <When condition={imgURL}>
+              <FRow className="post-image">
+                <button className="image-button" onClick={() => setPostImageModal(true)}>
+                  <img data-testid="post-image" className="clickable hover-outline" src={imgURL} onError={handlePictureImgError}/>
+                </button>
+              </FRow>
+            </When>
           </FCol>
         </FRow>
       </Container>

--- a/application/src/components/post/Post.js
+++ b/application/src/components/post/Post.js
@@ -86,7 +86,7 @@ function Post({postData}) {
       <Modal fullscreen show={postImageModal} onHide={() => setPostImageModal(false)}>
         <Modal.Header closeButton>{postData.title}</Modal.Header>
         <Modal.Body>
-          <img className="modal-image" src={postData.img_url} />
+          <img className="modal-image" src={imgURL} />
         </Modal.Body>
       </Modal>
 

--- a/application/src/components/post/Post.test.js
+++ b/application/src/components/post/Post.test.js
@@ -75,7 +75,7 @@ describe('Post Component', () => {
 
     expect(screen.getByTestId('post-body')).toBeVisible();
     expect(screen.getByTestId('map')).toBeVisible();
-    expect(screen.getByTestId('post-image')).not.toBeVisible();
+    expect(screen.queryByTestId('post-image')).not.toBeInTheDocument();
 
     // Check for avatar image
     let avatarImage = screen.getByTestId('avatar-image');

--- a/application/src/components/post/post.css
+++ b/application/src/components/post/post.css
@@ -45,6 +45,7 @@
 .post-body {
     /* Keep extra whitespace inside the description of the post (e.g., newlines) */
     white-space: pre-wrap;
+    width: 100%;
 }
 
 .tag-container {


### PR DESCRIPTION
## Summary of Work
- Fixed the issue where the picture didn't show up in the post preview when creating a post.
  - The `useState` wasn't set up properly to update based on the given props (need to do `useEffect`).
- Fixed the issue where posts with small body content didn't take the full width of the container.

| Before | After |
| ----------- | ----------- |
| <img src="https://user-images.githubusercontent.com/43451024/153716677-b9432b10-54b3-4bc6-b49d-0c5f2e6ad840.png"/> | <img src="https://user-images.githubusercontent.com/43451024/153716679-77a246f9-49ca-497b-a705-028b593add81.png"/> |
