### PR TITLE
Fix error/reset issues in home & search pages

### DIFF
--- a/application/src/components/Home.js
+++ b/application/src/components/Home.js
@@ -35,17 +35,25 @@ function Home() {
   }
 
   const loadMorePosts = () => {
-    // Update the last date (which will trigger getPosts)
+    // Call getpost even if lastDate hasn't changed
     const lastPost = posts[posts.length-1];
-    setLastDate(lastPost.date_created);
+    if (lastDate === lastPost.date_created) getPosts();
+    // Else update the last date (which will trigger getPosts)
+    else setLastDate(lastPost.date_created);
   }
 
   const getPosts = async () => {
     // Reset
     setIsError(false);
-    setError429Message(null)
-    setNumResults(0);
+    setError429Message(null);
 
+    // Reset UI on refresh
+    if (lastDate === null) {
+      setShowResults(false);
+      setNumResults(0);
+      setPosts([]);
+    }
+    
     // Add a minimum load time
     if (lastDate) fakeLoading(setIsPaginating);
     else fakeLoading(setIsLoading);
@@ -61,7 +69,7 @@ function Home() {
     else {
       // Error occured
       setIsError(true);
-      setError429Message(result.message)
+      setError429Message(result.message);
     }
 
     setShowResults(true);
@@ -111,17 +119,6 @@ function Home() {
         </FRow>
       </Container>
 
-      <When condition={isError && !isPaginating}>
-        <Container className="outer-container">
-          <Alert
-            variant="danger"
-            className="mb-0"
-          >
-            <MdErrorOutline/> {(error429Message)?error429Message:'Recent posts could not be retrieved. Please try again later.'}
-          </Alert>
-        </Container>
-      </When>
-
       <Fade in={showResults && (!isLoading || isPaginating)}>
         <div hidden={!(showResults && (!isLoading || isPaginating))}>
           <TransitionGroup>
@@ -137,6 +134,17 @@ function Home() {
               )
             }
           </TransitionGroup>
+
+          <When condition={isError && !isPaginating}>
+            <Container className="outer-container">
+              <Alert
+                variant="danger"
+                className="mb-0"
+              >
+                <MdErrorOutline/> {error429Message?error429Message:'Recent posts could not be retrieved. Please try again later.'}
+              </Alert>
+            </Container>
+          </When>
 
           <When condition={posts.length < numResults && !isPaginating}>
             <CenterContainer>

--- a/application/src/components/Search.js
+++ b/application/src/components/Search.js
@@ -26,6 +26,7 @@ function Search() {
   const [isLoading, setIsLoading] = useState(false);
   const [loadingTimerId, setLoadingTimerId] = useState(null);
   const [showResults, setShowResults] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [error429Message, setError429Message] = useState(null);
 
 
@@ -51,15 +52,17 @@ function Search() {
   }
 
   const getPosts = async () => {
-    setError429Message(null)
+    setIsError(false);
+    setError429Message(null);
 
     // Should not work if called without any tag selected
     if (searchTags.length === 0) return;
 
-    // Reset UI
+    // Reset UI on refresh
     if (page===1) {
       setShowResults(false);
       setNumResults(0);
+      setPosts([]);
     }
 
     // Add a minimum load time
@@ -76,8 +79,8 @@ function Search() {
     }
     else {
       // Error occured
-      setPosts([]);
-      setError429Message(result?.message)
+      setIsError(true);
+      setError429Message(result?.message);
     }
 
     setShowResults(true);
@@ -135,13 +138,6 @@ function Search() {
         >
           <MdErrorOutline/> You must select at least one tag.
         </Alert>
-        <Alert
-          variant="danger"
-          className="mb-0 mt-3"
-          hidden={!error429Message} 
-        >
-          <MdErrorOutline/> {error429Message}
-        </Alert>
         <Button 
           className="mt-3"
           disabled={!tags.length}
@@ -185,26 +181,34 @@ function Search() {
               </FRow>
             </Container>
 
-            <When condition={posts.length > 0}>
-              <TransitionGroup>
-                {
-                  posts.map((post) => 
-                    <CSSTransition
-                      key={post.uid}
-                      timeout={150}
-                      classNames="fade-in"
-                    >
-                      <Post postData={post}/>
-                    </CSSTransition>
-                  )
-                }
-              </TransitionGroup>
-              
-              <When condition={posts.length < numResults && !isPaginating}>
-                <CenterContainer>
-                  <Button onClick={loadMorePosts}>Load More</Button>
-                </CenterContainer>
-              </When>
+            <TransitionGroup>
+              {
+                posts.map((post) =>
+                  <CSSTransition
+                    key={post.uid}
+                    timeout={150}
+                    classNames="fade-in"
+                  >
+                    <Post postData={post}/>
+                  </CSSTransition>
+                )
+              }
+            </TransitionGroup>
+            
+            <When condition={isError && !isPaginating}>
+              <Container className="outer-container"><Alert
+                  variant="danger"
+                  className="mb-0"
+                >
+                  <MdErrorOutline/> {error429Message?error429Message:'Posts could not be retrieved. Please try again later.'}
+                </Alert>
+              </Container>
+            </When>
+            
+            <When condition={posts.length < numResults && !isPaginating}>
+              <CenterContainer>
+                <Button onClick={loadMorePosts}>Load More</Button>
+              </CenterContainer>
             </When>
           </div>
         </Fade>


### PR DESCRIPTION
While reviewing & testing Carter's PR for the 429 error messages I noticed some inconsistencies/issues with the Home & Search pages. I fixed them here.

Note: 
- I also took care of the few comments I had on Carter's changes, which were mostly about moving where the alert is shown on the Home & Search pages.
- This PR is set to merge into Carter's dbo-75 branch: #85